### PR TITLE
Add required module 'cloudpickle' to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ matplotlib
 zarr
 tifffile
 medmnist
+cloudpickle


### PR DESCRIPTION
When running the Jupyter demo for the very first time, I was asked to install cloudpickle.